### PR TITLE
feat: add AI page with tools I use

### DIFF
--- a/content/ai.md
+++ b/content/ai.md
@@ -1,0 +1,34 @@
+---
+title: "AI"
+description: "AI tools I use and ideas I'm exploring."
+---
+
+# AI
+
+## Tools I use
+
+### Coding agents
+
+- Claude Code
+- OpenCode
+- Pi
+
+### Orchestration & workflow
+
+- Conductor — running many coding agents in parallel
+- OpenSpec — spec-driven development
+
+### Local LLMs
+
+- Ollama
+
+### Models
+
+- Claude Opus 4.7
+- DeepSeek 4
+- Gemma 4
+
+### Infrastructure & gateways
+
+- OpenRouter — model routing across providers
+- Verda — green GPU cloud for AI workloads


### PR DESCRIPTION
## Summary
- New `/ai` page listing AI tools grouped by category (coding agents, orchestration, local LLMs, models, infrastructure)
- Auto-appears in the navbar via `queryCollectionNavigation`
- Regenerated content sqlite

## Test plan
- [x] Visit `/ai` and verify the page renders with all sections
- [x] Verify "AI" link appears in the desktop and mobile navbars