### PR TITLE
Add Hermes Agent to AI tools

### DIFF
--- a/content/ai.md
+++ b/content/ai.md
@@ -12,10 +12,12 @@ description: "AI tools I use and ideas I'm exploring."
 - Claude Code
 - OpenCode
 - Pi
+- Hermes Agent — extensible, multi-model agent with skills, cron, and subagent orchestration
 
 ### Orchestration & workflow
 
 - Conductor — running many coding agents in parallel
+- Hermes Agent — built-in cron scheduler and subagent delegation
 - OpenSpec — spec-driven development
 
 ### Local LLMs

--- a/content/ai.md
+++ b/content/ai.md
@@ -12,7 +12,6 @@ description: "AI tools I use and ideas I'm exploring."
 - Claude Code
 - OpenCode
 - Pi
-- Hermes Agent — extensible, multi-model agent with skills, cron, and subagent orchestration
 
 ### Orchestration & workflow
 


### PR DESCRIPTION
Adds Hermes Agent to the AI page under Orchestration and workflow. Hermes handles cron scheduling, skills-based workflows, and subagent delegation.